### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
@@ -11,15 +11,15 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.1.97.Final"))
+    api(platform("io.netty:netty-bom:4.1.104.Final"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation(platform("org.junit:junit-bom:5.10.1"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.4.0"))
+    testImplementation(platform("org.mockito:mockito-bom:5.8.0"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.15.2"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.16.0"))
     // rocketmq
-    api(platform("org.apache.rocketmq:rocketmq-all:5.1.3"))
+    api(platform("org.apache.rocketmq:rocketmq-all:5.1.4"))
     // kotlin coroutines
     api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3"))
     // prometheus
@@ -28,22 +28,22 @@ dependencies {
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.9.0"))
 
     constraints {
-        implementation("org.slf4j:slf4j-api:2.0.7")
-        implementation("ch.qos.logback:logback-classic:1.4.11")
-        api("io.lettuce:lettuce-core:6.2.5.RELEASE")
+        implementation("org.slf4j:slf4j-api:2.0.9")
+        implementation("ch.qos.logback:logback-classic:1.4.14")
+        api("io.lettuce:lettuce-core:6.3.0.RELEASE")
         api("com.dslplatform:dsl-json-java8:1.10.0")
         api("com.jsoniter:jsoniter:0.9.23")
-        api("com.aliyun.openservices:ons-client:2.0.5.Final")
-        val fastjson2Version = "2.0.40"
+        api("com.aliyun.openservices:ons-client:2.0.6.Final")
+        val fastjson2Version = "2.0.43"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
-        val mongodbVersion = "4.10.2"
+        val mongodbVersion = "4.11.1"
         api("org.mongodb:bson:$mongodbVersion")
         api("org.mongodb:mongodb-driver-core:$mongodbVersion")
         api("org.mongodb:mongodb-driver-sync:$mongodbVersion")
         api("org.mongodb:mongodb-driver-reactivestreams:$mongodbVersion")
         api("org.mongodb:mongodb-driver-legacy:$mongodbVersion")
-        val jrubyVersion = "9.4.2.0"
+        val jrubyVersion = "9.4.4.0"
         implementation("org.jruby:jruby-complete:$jrubyVersion")
         implementation("org.jruby:jruby:$jrubyVersion")
         implementation("org.jruby:jruby-core:$jrubyVersion")
@@ -51,7 +51,7 @@ dependencies {
         implementation("org.yaml:snakeyaml:2.0")
     }
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.20.0"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.22.0"))
 
 }
 


### PR DESCRIPTION
```
netty       4.1.97.Final  > 4.1.104.Final
junit       5.10.0        > 5.10.1
mockito     5.4.0         > 5.8.0
jackson     2.15.2        > 2.16.0
rocketmq    5.1.3         > 5.1.4
slf4j       2.0.7         > 2.0.9
logback     1.4.11        > 1.4.14
lettuce     6.2.5.RELEASE > 6.3.0.RELEASE
ons-client  2.0.5.Final   > 2.0.6.Final
fastjson2   2.0.40        > 2.0.43
mongodb     4.10.2        > 4.11.1
jruby       9.4.2.0       > 9.4.4.0
log4j       2.20.0        > 2.22.0
```