### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
@@ -11,39 +11,39 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.1.110.Final"))
+    api(platform("io.netty:netty-bom:4.1.114.Final"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation(platform("org.junit:junit-bom:5.11.2"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.12.0"))
+    testImplementation(platform("org.mockito:mockito-bom:5.14.1"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.17.1"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.18.0"))
     // rocketmq
-    api(platform("org.apache.rocketmq:rocketmq-all:5.2.0"))
+    api(platform("org.apache.rocketmq:rocketmq-all:5.3.1"))
     // kotlin coroutines
-    api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.8.1"))
+    api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0"))
     // prometheus
     api(platform("io.prometheus:simpleclient_bom:0.16.0"))
     // kotlin
     api(platform("org.jetbrains.kotlin:kotlin-bom:1.9.0"))
 
     constraints {
-        implementation("org.slf4j:slf4j-api:2.0.13")
-        implementation("ch.qos.logback:logback-classic:1.5.6")
-        api("io.lettuce:lettuce-core:6.3.2.RELEASE")
+        implementation("org.slf4j:slf4j-api:2.0.16")
+        implementation("ch.qos.logback:logback-classic:1.5.9")
+        api("io.lettuce:lettuce-core:6.4.0.RELEASE")
         api("com.dslplatform:dsl-json-java8:1.10.0")
         api("com.jsoniter:jsoniter:0.9.23")
         api("com.aliyun.openservices:ons-client:2.0.7.Final")
-        val fastjson2Version = "2.0.50"
+        val fastjson2Version = "2.0.53"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
-        val mongodbVersion = "5.1.0"
+        val mongodbVersion = "5.2.0"
         api("org.mongodb:bson:$mongodbVersion")
         api("org.mongodb:mongodb-driver-core:$mongodbVersion")
         api("org.mongodb:mongodb-driver-sync:$mongodbVersion")
         api("org.mongodb:mongodb-driver-reactivestreams:$mongodbVersion")
         api("org.mongodb:mongodb-driver-legacy:$mongodbVersion")
-        val jrubyVersion = "9.4.7.0"
+        val jrubyVersion = "9.4.8.0"
         implementation("org.jruby:jruby-complete:$jrubyVersion")
         implementation("org.jruby:jruby:$jrubyVersion")
         implementation("org.jruby:jruby-core:$jrubyVersion")
@@ -57,7 +57,7 @@ dependencies {
         api("io.prometheus:prometheus-metrics-instrumentation-jvm:$prometheusVersion")
     }
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.23.1"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.1"))
 
 }
 

--- a/buildSrc/src/main/kotlin/libcommon.kotlin-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.kotlin-library-conventions.gradle.kts
@@ -11,9 +11,9 @@ dependencies {
 
     constraints {
         // reactor-kotlin-extensions
-        implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.2.2")
+        implementation("io.projectreactor.kotlin:reactor-kotlin-extensions:1.2.3")
         // mockk
-        testImplementation("io.mockk:mockk:1.13.5")
+        testImplementation("io.mockk:mockk:1.13.13")
     }
 }
 


### PR DESCRIPTION
```
netty                4.1.110.Final > 4.1.114.Final
junit                5.10.2        > 5.11.2
mockito              5.12.0        > 5.14.1
jackson2             2.17.1        > 2.18.0
rocketmq             5.2.0         > 5.3.1
kotlinx-coroutines   1.8.1         > 1.9.0
slf4j                2.0.13        > 2.0.16
logback              1.5.6         > 1.5.9
lettuce              6.3.2.RELEASE > 6.4.0.RELEASE
fastjson2            2.0.50        > 2.0.53
mongodb              5.1.0         > 5.2.0
jruby                9.4.7.0       > 9.4.8.0
log4j                2.23.1        > 2.24.1
reactor-kotlin       1.2.2         > 1.2.3
mockk                1.13.5        > 1.13.13
```