### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.1.114.Final"))
+    api(platform("io.netty:netty-bom:4.1.116.Final"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.11.2"))
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.14.1"))
+    testImplementation(platform("org.mockito:mockito-bom:5.14.2"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.18.0"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.18.2"))
     // rocketmq
     api(platform("org.apache.rocketmq:rocketmq-all:5.3.1"))
     // kotlin coroutines
@@ -29,15 +29,15 @@ dependencies {
 
     constraints {
         implementation("org.slf4j:slf4j-api:2.0.16")
-        implementation("ch.qos.logback:logback-classic:1.5.9")
-        api("io.lettuce:lettuce-core:6.4.0.RELEASE")
+        implementation("ch.qos.logback:logback-classic:1.5.15")
+        api("io.lettuce:lettuce-core:6.5.1.RELEASE")
         api("com.dslplatform:dsl-json-java8:1.10.0")
         api("com.jsoniter:jsoniter:0.9.23")
         api("com.aliyun.openservices:ons-client:2.0.7.Final")
         val fastjson2Version = "2.0.53"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
-        val mongodbVersion = "5.2.0"
+        val mongodbVersion = "5.2.1"
         api("org.mongodb:bson:$mongodbVersion")
         api("org.mongodb:mongodb-driver-core:$mongodbVersion")
         api("org.mongodb:mongodb-driver-sync:$mongodbVersion")
@@ -57,7 +57,7 @@ dependencies {
         api("io.prometheus:prometheus-metrics-instrumentation-jvm:$prometheusVersion")
     }
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.1"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.24.3"))
 
 }
 


### PR DESCRIPTION
```
netty    4.1.114.Final > 4.1.116.Final
junit    5.11.2        > 5.11.4
mockito  5.14.1        > 5.14.2
jackson  2.18.0        > 2.18.2
logback  1.5.9         > 1.5.15
lettuce  6.4.0.RELEASE > 6.5.1.RELEASE
mongodb  5.2.0         > 5.2.1
log4j2   2.24.1        > 2.24.3
```