### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
@@ -12,53 +12,53 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.2.4.Final"))
+    api(platform("io.netty:netty-bom:4.2.6.Final"))
     // junit-bom
-    testImplementation(platform("org.junit:junit-bom:5.13.3"))
+    testImplementation(platform("org.junit:junit-bom:5.13.4"))
     // mockito
-    testImplementation(platform("org.mockito:mockito-bom:5.18.0"))
+    testImplementation(platform("org.mockito:mockito-bom:5.19.0"))
     // jackson2-bom
-    api(platform("com.fasterxml.jackson:jackson-bom:2.19.1"))
+    api(platform("com.fasterxml.jackson:jackson-bom:2.20.0"))
     // rocketmq
     api(platform("org.apache.rocketmq:rocketmq-all:5.3.3"))
     // kotlin coroutines
     api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2"))
     // prometheus
     api(platform("io.prometheus:simpleclient_bom:0.16.0"))
-    api(platform("io.prometheus:prometheus-metrics-bom:1.3.9"))
+    api(platform("io.prometheus:prometheus-metrics-bom:1.4.1"))
     // kotlin
-    api(platform("org.jetbrains.kotlin:kotlin-bom:2.1.0"))
+    api(platform("org.jetbrains.kotlin:kotlin-bom:2.2.0"))
     // spring boot
-    api(platform("org.springframework.boot:spring-boot-dependencies:3.5.3"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:3.5.5"))
 
     constraints {
         implementation("org.slf4j:slf4j-api:2.0.17")
         implementation("ch.qos.logback:logback-classic:1.5.18")
-        api("io.lettuce:lettuce-core:6.8.0.RELEASE")
+        api("io.lettuce:lettuce-core:6.8.1.RELEASE")
         api("com.dslplatform:dsl-json-java8:1.10.0")
         api("com.jsoniter:jsoniter:0.9.23")
         api("com.aliyun.openservices:ons-client:2.0.8.Final")
-        val fastjson2Version = "2.0.57"
+        val fastjson2Version = "2.0.58"
         api("com.alibaba.fastjson2:fastjson2:$fastjson2Version")
         api("com.alibaba.fastjson2:fastjson2-kotlin:$fastjson2Version")
-        val mongodbVersion = "5.5.1"
+        val mongodbVersion = "5.6.0"
         api("org.mongodb:bson:$mongodbVersion")
         api("org.mongodb:mongodb-driver-core:$mongodbVersion")
         api("org.mongodb:mongodb-driver-sync:$mongodbVersion")
         api("org.mongodb:mongodb-driver-reactivestreams:$mongodbVersion")
         api("org.mongodb:mongodb-driver-legacy:$mongodbVersion")
-        val jrubyVersion = "10.0.0.1"
+        val jrubyVersion = "10.0.2.0"
         implementation("org.jruby:jruby-complete:$jrubyVersion")
         implementation("org.jruby:jruby:$jrubyVersion")
         implementation("org.jruby:jruby-core:$jrubyVersion")
         implementation("org.jruby:jruby-stdlib:$jrubyVersion")
-        implementation("org.yaml:snakeyaml:2.2")
+        implementation("org.yaml:snakeyaml:2.5")
         api("javax.annotation:javax.annotation-api:1.3.2")
         api("jakarta.annotation:jakarta.annotation-api:3.0.0")
         api("com.google.code.findbugs:jsr305:3.0.2")
     }
     // log4j2
-    implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.0"))
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.1"))
 
 }
 
@@ -67,14 +67,23 @@ val javaVersion = 17
 java {
     withSourcesJar()
     withJavadocJar()
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     toolchain {
         languageVersion = JavaLanguageVersion.of(javaVersion)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
     }
 }
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
     options.release = javaVersion
+    options.compilerArgs = options.compilerArgs + listOf("-Xlint:deprecation")
 }
 
 tasks.withType<Javadoc> {

--- a/libcommon-json-jackson2/src/main/java/com/github/fmjsjx/libcommon/json/Jackson2Library.java
+++ b/libcommon-json-jackson2/src/main/java/com/github/fmjsjx/libcommon/json/Jackson2Library.java
@@ -62,7 +62,7 @@ public class Jackson2Library implements JsonLibrary<JsonNode> {
     }
 
     private static final ObjectMapper createDefaultObjectMapper() {
-        var mapper = new ObjectMapper().setSerializationInclusion(Include.NON_ABSENT)
+        var mapper = new ObjectMapper().setDefaultPropertyInclusion(Include.NON_ABSENT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         ReflectUtil.<Module>findForName("com.fasterxml.jackson.datatype.jdk8.Jdk8Module").ifPresent(moduleClass -> {
             try {

--- a/libcommon-kotlin/src/main/java/com/github/fmjsjx/libcommon/util/kotlin/KotlinReflectionUtil.java
+++ b/libcommon-kotlin/src/main/java/com/github/fmjsjx/libcommon/util/kotlin/KotlinReflectionUtil.java
@@ -81,7 +81,7 @@ public final class KotlinReflectionUtil {
      */
     public static boolean isSuspend(Method method) {
         if (KotlinUtil.isKotlinType(method.getDeclaringClass())) {
-            return findKotlinFunction(method).get().isSuspend();
+            return findKotlinFunction(method).map(KFunction::isSuspend).orElse(false);
         }
         return false;
     }


### PR DESCRIPTION
```
netty        4.2.4.Final   > 4.2.6.Final
junit        5.13.3        > 5.13.4
mockito      5.18.0        > 5.19.0
jackson      2.19.1        > 2.20.0
prometheus   1.3.9         > 1.4.1
kotlin       2.1.0         > 2.2.0
spring-boot  3.5.3         > 3.5.5
lettuce      6.8.0.RELEASE > 6.8.1.RELEASE
fastjson2    2.0.57        > 2.0.58
mongodb      5.5.1         > 5.6.0
jruby        10.0.0.1      > 10.0.2.0
snakeyaml    2.2           > 2.5
log4j        2.25.0        > 2.25.1
```