### PR TITLE
Upgrade Netty to 4.2.9.Final

### DIFF
--- a/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/libcommon.java-library-conventions.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // netty-bom
-    api(platform("io.netty:netty-bom:4.2.7.Final"))
+    api(platform("io.netty:netty-bom:4.2.9.Final"))
     // junit-bom
     testImplementation(platform("org.junit:junit-bom:6.0.1"))
     // mockito


### PR DESCRIPTION
Netty has a CRLF Injection vulnerability in `io.netty.handler.codec.http.HttpRequestEncoder`. 
Upgrade to version 4.2.9.Final to fix this issue.
See: [CVE-2025-67735](https://www.mend.io/vulnerability-database/CVE-2025-67735)